### PR TITLE
Regex list names

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -2,11 +2,11 @@ import { groupBy } from 'ramda';
 import { Card, Workflow, Action, ActionsByWorkflow } from './types';
 
 const hasRegexMatch = (candidates: string[], actionName) => {
-  for(let candidate of candidates){
-    if(candidate.indexOf('/') !== 0) continue;
+  for (let candidate of candidates) {
+    if (candidate.indexOf('/') !== 0) continue;
 
     let trimmedRegex = candidate.substring(1,candidate.length);
-    if(actionName.match(trimmedRegex) != null){
+    if (actionName.match(trimmedRegex) != null) {
       return true;
     }
   }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,20 @@
 import { groupBy } from 'ramda';
 import { Card, Workflow, Action, ActionsByWorkflow } from './types';
 
+const hasRegexMatch = (candidates: string[], actionName) => {
+  let found = false;
+  for(let candidate of candidates){
+    if(candidate.indexOf('/') !== 0) continue;
+
+    if(actionName.match(candidate.substring(1,candidate.length)) != null){
+      found = true;
+      break;
+    }
+  }
+
+  return found;
+}
+
 const addStagingDates = (card: Card, workflow: Workflow): Card => {
   // CARD context...
   // note, because we are using groupBy, you can't have an event in two different stage categories
@@ -17,7 +31,7 @@ const addStagingDates = (card: Card, workflow: Workflow): Card => {
   const eventsByStageCategory = groupBy(action => {
     for (let stageCategory in workflow) {
       const listsForThisStage = workflow[stageCategory];
-      if (listsForThisStage.includes(action.list.name)) {
+      if (listsForThisStage.includes(action.list.name) || hasRegexMatch(listsForThisStage, action.list.name)) {
         return stageCategory;
       }
     }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -2,17 +2,16 @@ import { groupBy } from 'ramda';
 import { Card, Workflow, Action, ActionsByWorkflow } from './types';
 
 const hasRegexMatch = (candidates: string[], actionName) => {
-  let found = false;
   for(let candidate of candidates){
     if(candidate.indexOf('/') !== 0) continue;
 
-    if(actionName.match(candidate.substring(1,candidate.length)) != null){
-      found = true;
-      break;
+    let trimmedRegex = candidate.substring(1,candidate.length);
+    if(actionName.match(trimmedRegex) != null){
+      return true;
     }
   }
 
-  return found;
+  return false;
 }
 
 const addStagingDates = (card: Card, workflow: Workflow): Card => {


### PR DESCRIPTION
In trying to use this tool some of our trello boards move things to a "Done" column and then to get it out of the way, the column is renamed in a common way and archived.  I would like the ability to configure the lists for a stage to include regex expressions.  To avoid overly checking every list name as regex, I included a / identifier in front of the name so that the code could detect it.

I'm not sure how active this code is, but my company has a lot of teams that use trello and have yet to find a good tool to extract metrics from it.  This feature would allow more of our teams to be able to make use of it.  Please consider incorporating this change and please let me know if there are modifications needed to fit it into the coding standards of the original code (as well as if there's any documentation needed to make sure people know how to use it).

thanks, Ben