### PR TITLE
Type mapping

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -50,6 +50,7 @@ const run = async function(cliArgs: any): Promise<void> {
     workflow: settings.Workflow,
     key: settings.Key,
     token: settings.Token,
+    types: settings.Types,
   });
   
   const output: string = await trelloExtractor.extractToCSV(settings.BoardId);

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -20,6 +20,7 @@ Workflow:
   Done: ["/[Ww]eek of"]
 
 # The types can be defined to map a Trello label to a work item type.  Cards without any matching labels will use the default specified.
+# NOTE: this section is OPTIONAL but if specified, you must have sub-properties set
 Types:
   labels: ["SPIKE", "DESIGN"]
   default: "Story"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -18,3 +18,8 @@ Workflow:
   Request: Request
   Doing: ['Doing', 'Waiting for delivery']
   Done: ["/[Ww]eek of"]
+
+# The types can be defined to map a Trello label to a work item type.  Cards without any matching labels will use the default specified.
+Types:
+  labels: ["SPIKE", "DESIGN"]
+  default: "Story"

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -61,7 +61,7 @@ const convertCardToWorkItem = (c: Card, domainUrl: string): WorkItem => {
     name: c.name,
     stageDates: c['stagingDates'],
     domainUrl,
-    type: '',
+    type: 'Card',
   });
 };
 

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,7 +1,7 @@
 import { WorkItem, createWorkItem, workItemToCSV } from './work-item';
 import { addMoreDetailToCardEventLog, addStagingDates } from './helper';
 import { getBoardsFromAuthedUserUrl, getBoardHistory, getBoardCards } from './api';
-import { Workflow, TypesConfig, Card, Board, TrelloConfig } from './types';
+import { Workflow, TypesConfig, Card, Label, Board, TrelloConfig } from './types';
 
 class TrelloExtractor {
   private readonly baseUrl: string = 'https://api.trello.com';
@@ -56,7 +56,12 @@ class TrelloExtractor {
     return csv;
   }
 
-  mapLabelsToType(labels: Array<string>) {
+  mapLabelsToType(labels: Array<Label>) {
+    for(let label of labels) {
+      if(this.typesConfig.labels.indexOf(label.name) >= 0) {
+        return label.name;
+      } 
+    }
     return this.typesConfig.default;
   }
 

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -70,7 +70,7 @@ class TrelloExtractor {
       id: c.id,
       name: c.name,
       stageDates: c['stagingDates'],
-      domainUrl: this.baseUrl,
+      url: c.shortUrl,
       type: this.mapLabelsToType(c.labels),
     });
   };

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -16,7 +16,7 @@ class TrelloExtractor {
     this.key = config.key;
     this.token = config.token;
     this.workflow = config.workflow;
-    this.typesConfig = config.types;
+    this.typesConfig = config.types || { default: 'Card', labels: [] };
   }
 
   public async getAuthedUsersProjects(): Promise<Board[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,16 @@ export interface Board {
   url: string;
 };
 
+export interface Label {
+  name: string;
+}
+
 export interface Card {
   id: string;
   due: string;
   closed: boolean;
   name: string;
-  labels: Array<any>;
+  labels: Array<Label>;
   url: string;
   actions: Array<Action>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface Card {
   labels: Array<Label>;
   url: string;
   actions: Array<Action>;
+  shortUrl: string;
 };
 
 export interface Action {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,11 @@ export interface Workflow {
   [category: string]: Array<string>;
 };
 
+export interface TypesConfig {
+  default: string;
+  labels: Array<string>;
+};
+
 export interface ActionsByWorkflow {
   [workflowCategory: string]: Array<Action>;
 };
@@ -40,6 +45,7 @@ export interface TrelloConfig {
   workflow: Workflow;
   key: string;
   token: string;
+  types: TypesConfig;
 };
 
 export interface BoardHistory { 

--- a/src/work-item.ts
+++ b/src/work-item.ts
@@ -3,25 +3,25 @@ export interface WorkItem {
   stageDates: Array<string>;
   name: string;
   type: string;
-  domainUrl: string;
+  url: string;
   attributes?: any;
 };
 
 // Doesn't do a whole lot at the moment, might consider getting rid of it.
-const createWorkItem = ({id, stageDates, name, type, domainUrl}): WorkItem => {
+const createWorkItem = ({id, stageDates, name, type, url}): WorkItem => {
   return ({
     id,
     stageDates,
     name,
     type,
-    domainUrl,
+    url,
   });
 };
 
 const workItemToCSV = (workItem: WorkItem) => {
   let s = '';
   s += `${workItem.id},`;
-  s += `${workItem.domainUrl}/${workItem.id},`;
+  s += `${workItem.url},`;
   s += `${(cleanString(workItem.name))}`;
   workItem.stageDates.forEach(stageDate => s += `,${stageDate}`);
   s += `,${workItem.type}`;


### PR DESCRIPTION
Want to fix the Type column in output to have a value.  Using Trello Labels to achieve this.  Because labels can be used for a number of reasons, the user must configure which labels they want to map to types.  They can also specify a default type for all work items (previously was leaving the type blank for everything which kind of messes up Actionable Agile import)

Also, fixed a url problem that's been nagging me when using the data (links were broken in the tool because the exporter was assuming you could append the id to the url...actually the url is on the api payload so using that instead)